### PR TITLE
Update subtake.sh - Added timeout

### DIFF
--- a/modules/subtake.sh
+++ b/modules/subtake.sh
@@ -6,7 +6,7 @@ url=$1
 echo "10) SUBDOMAINS TAKEOVER CHECK" >> /app/results/$url-output.txt
 printf "\n\n" >> /app/results/$url-output.txt
 
-/app/modules/binaries/subzy -concurrency 90 -timeout 5 -hide_fails -targets /app/$url-subs | sed -r "s/\x1B\[([0-9]{1,3}(;[0-9]{1,2})?)?[mGK]//g" | tee -a /app/results/$url-output.txt
+/app/modules/binaries/subzy -concurrency 90 -timeout 20 -hide_fails -targets /app/$url-subs | sed -r "s/\x1B\[([0-9]{1,3}(;[0-9]{1,2})?)?[mGK]//g" | tee -a /app/results/$url-output.txt
 
 printf "\n\n\n" >> /app/results/$url-output.txt
 printf "##########################################################################################\n" >> /app/results/$url-output.txt


### PR DESCRIPTION
Hi, I have added ``-timeout 20`` to **subzy** to reduce the number of false positive results. I have seen that **subzy** waits for 5 sec only which is not able to detect domains that take a longer time to load hence subzy ignores it and 20 sec is the ideal time I have seen to detect most of the domains that doesn't respond quickly.